### PR TITLE
feat: Add Cloudflare AI Gateway support for OpenAI API calls

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,12 @@
 OPENAI_API_KEY=sk-your-openai-key
 OPENAI_CHAT_MODEL=gpt-4.1-mini
 
+# Cloudflare AI Gateway Configuration (Optional - helps bypass regional restrictions)
+# CF_AI_GATEWAY_ACCOUNT_ID=your-cloudflare-account-id
+# CF_AI_GATEWAY_NAME=your-gateway-name
+# Alternative: Custom gateway URL
+# CF_AI_GATEWAY_BASE_URL=https://custom-gateway.example.com/v1/openai
+
 # Qdrant Configuration
 QDRANT_CLOUD_URL=https://your-qdrant-endpoint
 QDRANT_API_KEY=your-qdrant-api-key

--- a/src/core/handler.ts
+++ b/src/core/handler.ts
@@ -184,6 +184,7 @@ function validateWebhookSecret(request: Request, env: Env): boolean {
 async function getRagAnswer(question: string, cfg: any) {
   const rag = await createEnhancedRag({
     openaiApiKey: cfg.openaiApiKey,
+    openaiBaseUrl: cfg.openai.baseUrl,
     qdrantUrl: cfg.qdrant.url,
     qdrantApiKey: cfg.qdrant.apiKey,
     qdrantCollection: cfg.qdrant.collection,

--- a/src/rag/rag.ts
+++ b/src/rag/rag.ts
@@ -246,6 +246,7 @@ export function buildRagStream(opts: {
 
 export async function createEnhancedRag(cfg: {
   openaiApiKey: string;
+  openaiBaseUrl?: string;
   qdrantUrl: string;
   qdrantApiKey: string;
   qdrantCollection: string;
@@ -263,6 +264,7 @@ export async function createEnhancedRag(cfg: {
       apiKey: cfg.openaiApiKey,
       input: q,
       model: "text-embedding-3-large",
+      baseUrl: cfg.openaiBaseUrl,
     });
 
   const searchBoth = async (
@@ -326,6 +328,7 @@ export async function createEnhancedRag(cfg: {
         { role: "user", content: buildUserMessage(user, context) },
       ],
       maxTokens: 500,
+      baseUrl: cfg.openaiBaseUrl,
     });
 
   return buildRag({
@@ -340,6 +343,7 @@ export async function createEnhancedRag(cfg: {
 
 export async function createEnhancedRagStream(cfg: {
   openaiApiKey: string;
+  openaiBaseUrl?: string;
   qdrantUrl: string;
   qdrantApiKey: string;
   qdrantCollection: string;
@@ -357,6 +361,7 @@ export async function createEnhancedRagStream(cfg: {
       apiKey: cfg.openaiApiKey,
       input: q,
       model: "text-embedding-3-large",
+      baseUrl: cfg.openaiBaseUrl,
     });
 
   const searchBoth = async (
@@ -421,6 +426,7 @@ export async function createEnhancedRagStream(cfg: {
       ],
       maxTokens: 500,
       temperature: 0.1,
+      baseUrl: cfg.openaiBaseUrl,
     });
   };
 

--- a/src/services/openai.ts
+++ b/src/services/openai.ts
@@ -6,13 +6,15 @@ export async function createEmbedding(opts: {
   apiKey: string
   input: string | string[]
   model: string
+  baseUrl?: string
   fetchImpl?: FetchLike
 }): Promise<number[]> {
   return measureAsync('OpenAI Embedding API', async () => {
-    const { apiKey, input, model, fetchImpl = fetch } = opts
+    const { apiKey, input, model, baseUrl = 'https://api.openai.com/v1', fetchImpl = fetch } = opts
     
     log('debug', 'Creating OpenAI embedding', {
       model,
+      baseUrl,
       inputType: Array.isArray(input) ? 'array' : 'string',
       // 배열일 경우 아이템 수가 아니라 전체 문자열 길이 합계를 기록
       inputLength: Array.isArray(input)
@@ -20,7 +22,7 @@ export async function createEmbedding(opts: {
         : input.length
     })
     
-    const res = await fetchWithRetry('https://api.openai.com/v1/embeddings', {
+    const res = await fetchWithRetry(`${baseUrl}/embeddings`, {
       method: 'POST',
       headers: {
         'content-type': 'application/json',
@@ -52,13 +54,15 @@ export async function chatComplete(opts: {
   messages: { role: 'system' | 'user' | 'assistant'; content: string }[]
   temperature?: number
   maxTokens?: number
+  baseUrl?: string
   fetchImpl?: FetchLike
 }): Promise<string> {
   return measureAsync('OpenAI Chat Completion API', async () => {
-    const { apiKey, model, messages, temperature = 0.1, maxTokens = 500, fetchImpl = fetch } = opts
+    const { apiKey, model, messages, temperature = 0.1, maxTokens = 500, baseUrl = 'https://api.openai.com/v1', fetchImpl = fetch } = opts
     
     log('debug', 'Starting OpenAI chat completion', {
       model,
+      baseUrl,
       messageCount: messages.length,
       temperature,
       maxTokens,
@@ -66,7 +70,7 @@ export async function chatComplete(opts: {
       userPromptLength: messages.find(m => m.role === 'user')?.content?.length
     })
     
-    const res = await fetchWithRetry('https://api.openai.com/v1/chat/completions', {
+    const res = await fetchWithRetry(`${baseUrl}/chat/completions`, {
       method: 'POST',
       headers: {
         'content-type': 'application/json',
@@ -101,12 +105,14 @@ export async function* chatCompleteStream(opts: {
   messages: { role: 'system' | 'user' | 'assistant'; content: string }[]
   temperature?: number
   maxTokens?: number
+  baseUrl?: string
   fetchImpl?: FetchLike
 }): AsyncGenerator<string, void, unknown> {
-  const { apiKey, model, messages, temperature = 0.1, maxTokens = 500, fetchImpl = fetch } = opts
+  const { apiKey, model, messages, temperature = 0.1, maxTokens = 500, baseUrl = 'https://api.openai.com/v1', fetchImpl = fetch } = opts
   
   log('debug', 'Starting OpenAI chat completion stream', {
     model,
+    baseUrl,
     messageCount: messages.length,
     temperature,
     maxTokens,
@@ -114,7 +120,7 @@ export async function* chatCompleteStream(opts: {
     userPromptLength: messages.find(m => m.role === 'user')?.content?.length
   })
 
-  const res = await fetchWithRetry('https://api.openai.com/v1/chat/completions', {
+  const res = await fetchWithRetry(`${baseUrl}/chat/completions`, {
     method: 'POST',
     headers: {
       'content-type': 'application/json',

--- a/tests/core/config/ai-gateway.test.ts
+++ b/tests/core/config/ai-gateway.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest'
+import { loadConfig } from '../../../src/core/config.js'
+import type { Env } from '../../../src/core/types.js'
+
+describe('AI Gateway Configuration', () => {
+  const baseEnv: Env = {
+    OPENAI_API_KEY: 'sk-test',
+    QDRANT_API_KEY: 'test-key',
+    QDRANT_CLOUD_URL: 'https://test.qdrant.io',
+    QDRANT_COLLECTION: 'test-collection',
+    TELEGRAM_BOT_TOKEN: 'test-token',
+    WEBHOOK_SECRET_TOKEN: 'test-secret',
+  }
+
+  describe('AI Gateway URL Configuration', () => {
+    it('should use default OpenAI endpoints when AI Gateway is not configured', () => {
+      const config = loadConfig(baseEnv)
+      
+      expect(config.openai).toEqual({
+        apiKey: 'sk-test',
+        baseUrl: 'https://api.openai.com/v1',
+        gatewayEnabled: false
+      })
+    })
+
+    it('should configure AI Gateway when CF_AI_GATEWAY_ACCOUNT_ID and CF_AI_GATEWAY_NAME are provided', () => {
+      const envWithGateway: Env = {
+        ...baseEnv,
+        CF_AI_GATEWAY_ACCOUNT_ID: 'account123',
+        CF_AI_GATEWAY_NAME: 'my-gateway'
+      }
+
+      const config = loadConfig(envWithGateway)
+      
+      expect(config.openai).toEqual({
+        apiKey: 'sk-test',
+        baseUrl: 'https://gateway.ai.cloudflare.com/v1/account123/my-gateway/openai',
+        gatewayEnabled: true
+      })
+    })
+
+    it('should throw error when only one AI Gateway parameter is provided', () => {
+      const envMissingName: Env = {
+        ...baseEnv,
+        CF_AI_GATEWAY_ACCOUNT_ID: 'account123'
+      }
+
+      expect(() => loadConfig(envMissingName))
+        .toThrow('Both CF_AI_GATEWAY_ACCOUNT_ID and CF_AI_GATEWAY_NAME are required for AI Gateway')
+    })
+
+    it('should throw error when only AI Gateway name is provided', () => {
+      const envMissingAccount: Env = {
+        ...baseEnv,
+        CF_AI_GATEWAY_NAME: 'my-gateway'
+      }
+
+      expect(() => loadConfig(envMissingAccount))
+        .toThrow('Both CF_AI_GATEWAY_ACCOUNT_ID and CF_AI_GATEWAY_NAME are required for AI Gateway')
+    })
+
+    it('should validate AI Gateway account ID format', () => {
+      const envInvalidAccount: Env = {
+        ...baseEnv,
+        CF_AI_GATEWAY_ACCOUNT_ID: '',
+        CF_AI_GATEWAY_NAME: 'my-gateway'
+      }
+
+      expect(() => loadConfig(envInvalidAccount))
+        .toThrow('CF_AI_GATEWAY_ACCOUNT_ID cannot be empty')
+    })
+
+    it('should validate AI Gateway name format', () => {
+      const envInvalidName: Env = {
+        ...baseEnv,
+        CF_AI_GATEWAY_ACCOUNT_ID: 'account123',
+        CF_AI_GATEWAY_NAME: ''
+      }
+
+      expect(() => loadConfig(envInvalidName))
+        .toThrow('CF_AI_GATEWAY_NAME cannot be empty')
+    })
+
+    it('should allow custom base URL override', () => {
+      const envWithCustomUrl: Env = {
+        ...baseEnv,
+        CF_AI_GATEWAY_BASE_URL: 'https://custom-gateway.example.com/v1/openai'
+      }
+
+      const config = loadConfig(envWithCustomUrl)
+      
+      expect(config.openai).toEqual({
+        apiKey: 'sk-test',
+        baseUrl: 'https://custom-gateway.example.com/v1/openai',
+        gatewayEnabled: true
+      })
+    })
+  })
+})

--- a/tests/services/openai/ai-gateway.test.ts
+++ b/tests/services/openai/ai-gateway.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { createEmbedding, chatComplete } from '../../../src/services/openai.js'
+
+describe('OpenAI AI Gateway Integration', () => {
+  let mockFetch: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    mockFetch = vi.fn()
+    vi.clearAllMocks()
+  })
+
+  describe('createEmbedding with AI Gateway', () => {
+    it('should use AI Gateway URL for embedding requests', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({
+          data: [{ embedding: [0.1, 0.2, 0.3] }],
+          usage: { total_tokens: 10 }
+        })
+      })
+
+      await createEmbedding({
+        apiKey: 'sk-test',
+        input: 'test query',
+        model: 'text-embedding-3-large',
+        baseUrl: 'https://gateway.ai.cloudflare.com/v1/account123/my-gateway/openai',
+        fetchImpl: mockFetch
+      })
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://gateway.ai.cloudflare.com/v1/account123/my-gateway/openai/embeddings',
+        expect.objectContaining({
+          method: 'POST',
+          headers: expect.objectContaining({
+            'content-type': 'application/json',
+            'authorization': 'Bearer sk-test'
+          }),
+          body: JSON.stringify({
+            input: 'test query',
+            model: 'text-embedding-3-large'
+          })
+        })
+      )
+    })
+
+    it('should fallback to default OpenAI URL when baseUrl is not provided', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({
+          data: [{ embedding: [0.1, 0.2, 0.3] }],
+          usage: { total_tokens: 10 }
+        })
+      })
+
+      await createEmbedding({
+        apiKey: 'sk-test',
+        input: 'test query',
+        model: 'text-embedding-3-large',
+        fetchImpl: mockFetch
+      })
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://api.openai.com/v1/embeddings',
+        expect.any(Object)
+      )
+    })
+  })
+
+  describe('chatComplete with AI Gateway', () => {
+    it('should use AI Gateway URL for chat completion requests', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({
+          choices: [{ message: { content: 'Test response' } }],
+          usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 }
+        })
+      })
+
+      await chatComplete({
+        apiKey: 'sk-test',
+        model: 'gpt-4o-mini',
+        messages: [{ role: 'user', content: 'test message' }],
+        baseUrl: 'https://gateway.ai.cloudflare.com/v1/account123/my-gateway/openai',
+        fetchImpl: mockFetch
+      })
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://gateway.ai.cloudflare.com/v1/account123/my-gateway/openai/chat/completions',
+        expect.objectContaining({
+          method: 'POST',
+          headers: expect.objectContaining({
+            'content-type': 'application/json',
+            'authorization': 'Bearer sk-test'
+          }),
+          body: JSON.stringify({
+            model: 'gpt-4o-mini',
+            messages: [{ role: 'user', content: 'test message' }],
+            temperature: 0.1,
+            max_tokens: 500
+          })
+        })
+      )
+    })
+
+    it('should preserve all request headers when using AI Gateway', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({
+          choices: [{ message: { content: 'Test response' } }],
+          usage: { total_tokens: 15 }
+        })
+      })
+
+      await chatComplete({
+        apiKey: 'sk-test-key-123',
+        model: 'gpt-4o-mini',
+        messages: [{ role: 'system', content: 'system prompt' }],
+        baseUrl: 'https://gateway.ai.cloudflare.com/v1/test-account/test-gateway/openai',
+        fetchImpl: mockFetch
+      })
+
+      const [, requestInit] = mockFetch.mock.calls[0]
+      expect(requestInit.headers).toEqual({
+        'content-type': 'application/json',
+        'authorization': 'Bearer sk-test-key-123'
+      })
+    })
+  })
+
+  describe('Error handling with AI Gateway', () => {
+    it('should use correct URLs for AI Gateway requests', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({
+          data: [{ embedding: [0.1, 0.2, 0.3] }],
+          usage: { total_tokens: 10 }
+        })
+      })
+
+      await createEmbedding({
+        apiKey: 'sk-test',
+        input: 'test',
+        model: 'text-embedding-3-large',
+        baseUrl: 'https://gateway.ai.cloudflare.com/v1/account123/my-gateway/openai',
+        fetchImpl: mockFetch
+      })
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://gateway.ai.cloudflare.com/v1/account123/my-gateway/openai/embeddings',
+        expect.any(Object)
+      )
+    })
+
+    it('should maintain retry behavior with AI Gateway URLs', async () => {
+      // First call fails with 429
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 429,
+          text: () => Promise.resolve('Rate limit exceeded')
+        })
+        // Second call succeeds
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({
+            choices: [{ message: { content: 'Success after retry' } }],
+            usage: { total_tokens: 10 }
+          })
+        })
+
+      const result = await chatComplete({
+        apiKey: 'sk-test',
+        model: 'gpt-4o-mini',
+        messages: [{ role: 'user', content: 'test' }],
+        baseUrl: 'https://gateway.ai.cloudflare.com/v1/account123/my-gateway/openai',
+        fetchImpl: mockFetch
+      })
+
+      expect(result).toBe('Success after retry')
+      expect(mockFetch).toHaveBeenCalledTimes(2)
+    })
+  })
+})

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -28,6 +28,14 @@ RATE_LIMIT_KV_CLEANUP_THRESHOLD = "3600000"
 BOARD_COLLECTION_TOP_K = "2"
 POLICY_COLLECTION_TOP_K = "3"
 
+# Cloudflare AI Gateway Configuration (Optional)
+# Uncomment and configure these variables to use CF AI Gateway for OpenAI API calls
+# This can help bypass regional restrictions and provide additional analytics
+CF_AI_GATEWAY_ACCOUNT_ID = "6ed03d41ee9287a3e0e5bde9a6772812"
+CF_AI_GATEWAY_NAME = "knue-campus-counsel-gateway"
+# Alternative: Use custom base URL
+# CF_AI_GATEWAY_BASE_URL = "https://custom-gateway.example.com/v1/openai"
+
 [[kv_namespaces]]
 binding = "RATE_LIMIT_KV"
 id = "ff1c6ebb4b944a2c904128171ef99719"


### PR DESCRIPTION
- Implement AI Gateway URL configuration in config system
- Add baseUrl parameter support to OpenAI service functions
- Update RAG pipeline to use configurable OpenAI endpoints
- Add comprehensive test coverage for AI Gateway functionality
- Support both CF AI Gateway and custom gateway URLs
- Maintain backward compatibility with default OpenAI endpoints

This enables bypassing regional restrictions and provides additional
analytics/caching capabilities through Cloudflare's AI Gateway.

Configuration options:
- CF_AI_GATEWAY_ACCOUNT_ID + CF_AI_GATEWAY_NAME for CF AI Gateway
- CF_AI_GATEWAY_BASE_URL for custom gateway endpoints

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>